### PR TITLE
feat : 배송지 등록, 내 정보 수정

### DIFF
--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/controller/UserController.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/controller/UserController.java
@@ -2,16 +2,16 @@ package com.teamgold.goldenharvest.domain.user.command.application.controller;
 
 import com.teamgold.goldenharvest.common.response.ApiResponse;
 import com.teamgold.goldenharvest.common.security.CustomUserDetails;
+import com.teamgold.goldenharvest.domain.user.command.application.dto.reponse.UserProfileResponse;
+import com.teamgold.goldenharvest.domain.user.command.application.dto.request.UserProfileUpdateRequest;
 import com.teamgold.goldenharvest.domain.user.command.application.dto.request.PasswordChangeRequest;
 import com.teamgold.goldenharvest.domain.user.command.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
@@ -28,5 +28,24 @@ public class UserController {
 
         userService.changePassword(userDetails.getEmail(), request);
         return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 변경되었습니다."));
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<String>> updateAddress(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody UserProfileUpdateRequest userProfileUpdateRequest) {
+
+        userService.updateProfile(userDetails.getUsername(), userProfileUpdateRequest);
+
+        return ResponseEntity.ok(ApiResponse.success("회원 정보가 성공적으로 수정되었습니다."));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UserProfileResponse userProfileResponse = userService.getUserProfile(userDetails.getUsername());
+
+        return ResponseEntity.ok(ApiResponse.success(userProfileResponse));
     }
 }

--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/dto/reponse/UserProfileResponse.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/dto/reponse/UserProfileResponse.java
@@ -1,0 +1,20 @@
+package com.teamgold.goldenharvest.domain.user.command.application.dto.reponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserProfileResponse {
+    private String email;
+    private String name;
+    private String company;
+    private String businessNumber;
+    private String phoneNumber;
+    private String addressLine1;
+    private String addressLine2;
+    private String postalCode;
+    private String status;
+}

--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.teamgold.goldenharvest.domain.user.command.application.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileUpdateRequest {
+    private String name;
+    private String phoneNumber;
+    private String addressLine1;
+    private String addressLine2;
+    private String postalCode;
+}

--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/service/UserService.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/service/UserService.java
@@ -1,9 +1,14 @@
 package com.teamgold.goldenharvest.domain.user.command.application.service;
 
+import com.teamgold.goldenharvest.domain.user.command.application.dto.reponse.UserProfileResponse;
+import com.teamgold.goldenharvest.domain.user.command.application.dto.request.UserProfileUpdateRequest;
 import com.teamgold.goldenharvest.domain.user.command.application.dto.request.PasswordChangeRequest;
-import com.teamgold.goldenharvest.domain.user.command.domain.User;
 
 public interface UserService {
 
     void changePassword(String email, PasswordChangeRequest request);
+
+    void updateProfile(String email, UserProfileUpdateRequest userProfileUpdateRequest);
+
+    UserProfileResponse getUserProfile(String email);
 }

--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/service/UserServiceImpl.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/application/service/UserServiceImpl.java
@@ -2,6 +2,8 @@ package com.teamgold.goldenharvest.domain.user.command.application.service;
 
 import com.teamgold.goldenharvest.common.exception.BusinessException;
 import com.teamgold.goldenharvest.common.exception.ErrorCode;
+import com.teamgold.goldenharvest.domain.user.command.application.dto.reponse.UserProfileResponse;
+import com.teamgold.goldenharvest.domain.user.command.application.dto.request.UserProfileUpdateRequest;
 import com.teamgold.goldenharvest.domain.user.command.application.dto.request.PasswordChangeRequest;
 import com.teamgold.goldenharvest.domain.user.command.domain.User;
 import com.teamgold.goldenharvest.domain.user.command.infrastructure.repository.UserRepository;
@@ -45,5 +47,40 @@ public class UserServiceImpl implements UserService{
 
         log.info("[Golden Harvest] 마이페이지 비밀번호 변경 완료: {}", email);
 
+    }
+
+    @Override
+    public void updateProfile(String email, UserProfileUpdateRequest userProfileUpdateRequest) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateProfile(
+                userProfileUpdateRequest.getName(),
+                userProfileUpdateRequest.getPhoneNumber(),
+                userProfileUpdateRequest.getAddressLine1(),
+                userProfileUpdateRequest.getAddressLine2(),
+                userProfileUpdateRequest.getPostalCode()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(String email) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return UserProfileResponse.builder()
+                .email(user.getEmail())
+                .name(user.getName())
+                .company(user.getCompany())
+                .businessNumber(user.getBusinessNumber())
+                .phoneNumber(user.getPhoneNumber())
+                .addressLine1(user.getAddressLine1())
+                .addressLine2(user.getAddressLine2())
+                .postalCode(user.getPostalCode())
+                .status(user.getStatus().name())
+                .build();
     }
 }

--- a/src/main/java/com/teamgold/goldenharvest/domain/user/command/domain/User.java
+++ b/src/main/java/com/teamgold/goldenharvest/domain/user/command/domain/User.java
@@ -97,4 +97,12 @@ public class User {
     public void updatePassword(String encodePassword) {
         this.password = encodePassword;
     }
+
+    public void updateProfile(String name, String phoneNumber,String addressLine1, String addressLine2, String postalCode) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.postalCode = postalCode;
+    }
 }

--- a/src/test/java/com/teamgold/goldenharvest/user/UserQueryServiceTest.java
+++ b/src/test/java/com/teamgold/goldenharvest/user/UserQueryServiceTest.java
@@ -1,0 +1,59 @@
+package com.teamgold.goldenharvest.user;
+
+import com.teamgold.goldenharvest.domain.user.command.application.dto.reponse.UserProfileResponse;
+import com.teamgold.goldenharvest.domain.user.command.application.service.UserServiceImpl;
+import com.teamgold.goldenharvest.domain.user.command.domain.User;
+import com.teamgold.goldenharvest.domain.user.command.domain.UserStatus;
+import com.teamgold.goldenharvest.domain.user.command.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public @ExtendWith(MockitoExtension.class)
+class UserQueryServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("로그인한 유저의 이메일로 프로필 정보를 정확히 조회한다")
+    void getUserProfile_Success() {
+        // given
+        String email = "gold@harvest.com";
+        User user = User.builder()
+                .email(email)
+                .name("김농부")
+                .company("황금농장")
+                .phoneNumber("010-1111-2222")
+                .status(UserStatus.ACTIVE)
+                .addressLine1("경기도 부천시")
+                .postalCode("12345")
+                .build();
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // when
+        UserProfileResponse response = userService.getUserProfile(email);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(email);
+        assertThat(response.getName()).isEqualTo("김농부");
+        assertThat(response.getCompany()).isEqualTo("황금농장");
+        assertThat(response.getAddressLine1()).isEqualTo("경기도 부천시");
+
+        // 조회의 핵심: 필드 누락이 없는지 검증
+        verify(userRepository, times(1)).findByEmail(email);
+    }
+}

--- a/src/test/java/com/teamgold/goldenharvest/user/UserServiceTest.java
+++ b/src/test/java/com/teamgold/goldenharvest/user/UserServiceTest.java
@@ -1,0 +1,58 @@
+package com.teamgold.goldenharvest.user;
+
+import com.teamgold.goldenharvest.domain.user.command.application.dto.request.UserProfileUpdateRequest;
+import com.teamgold.goldenharvest.domain.user.command.application.service.UserServiceImpl;
+import com.teamgold.goldenharvest.domain.user.command.domain.User;
+import com.teamgold.goldenharvest.domain.user.command.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+
+public @ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("회원 정보 수정 성공 테스트")
+    void updateProfile_Success() {
+        // given
+        String email = "test@example.com";
+        User user = User.builder()
+                .email(email)
+                .name("이전이름")
+                .phoneNumber("010-0000-0000")
+                .build();
+
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .name("새이름")
+                .phoneNumber("010-1234-5678")
+                .addressLine1("서울시")
+                .addressLine2("강남구")
+                .postalCode("12345")
+                .build();
+
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // when
+        userService.updateProfile(email, request);
+
+        // then
+        assertThat(user.getName()).isEqualTo("새이름");
+        assertThat(user.getPhoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(user.getAddressLine1()).isEqualTo("서울시");
+    }
+}


### PR DESCRIPTION
USR_008
USR_009
- 배송지 등록 뿐 아니라 내정보 수정 까지 가능하게 구현한 뒤 요구사항 명세서도 수정하였습니다.
- 변동이 비교적 잦을 수 있는 담당자 이름, 연락처 등만 사용자가 변경할 수 있도록 구현하였고 회사명, 사업자등록증, 이메일 등 비즈니스 신뢰도가 필요한 정보는 재검토가 필요하기에 수정 요청을 누르면 관리자가 증빙서류 확인 후 수정하는 방식으로 구현할 예정입니다.
- 테스트 코드 작성 완료